### PR TITLE
bugfix: Update model_dump calls for optional fields handling

### DIFF
--- a/aymurai/database/crud/anonymization/paragraph.py
+++ b/aymurai/database/crud/anonymization/paragraph.py
@@ -49,7 +49,7 @@ def anonymization_paragraph_update(
     if not paragraph:
         raise ValueError(f"Paragraph not found: {paragraph_id}")
 
-    for field, value in paragraph_in.model_dump(exclude_unset=True).items():
+    for field, value in paragraph_in.model_dump(exclude_none=True).items():
         setattr(paragraph, field, value)
 
     session.add(paragraph)
@@ -83,7 +83,7 @@ def anonymization_paragraph_batch_create_update(
         if paragraph:
             update = AnonymizationParagraphUpdate(**p_in.model_dump())
 
-            for field, value in update.model_dump(exclude_unset=True).items():
+            for field, value in update.model_dump(exclude_none=True).items():
                 setattr(paragraph, field, value)
 
         else:

--- a/aymurai/database/crud/datapublic/paragraph.py
+++ b/aymurai/database/crud/datapublic/paragraph.py
@@ -2,13 +2,13 @@ import uuid
 
 from sqlmodel import Session, select
 
-from aymurai.logger import get_logger
-from aymurai.database.utils import text_to_uuid
 from aymurai.database.schema import (
     DataPublicParagraph,
     DataPublicParagraphCreate,
     DataPublicParagraphUpdate,
 )
+from aymurai.database.utils import text_to_uuid
+from aymurai.logger import get_logger
 
 logger = get_logger(__name__)
 
@@ -59,7 +59,7 @@ def datapublic_paragraph_update(
     if not paragraph:
         raise ValueError(f"Paragraph not found: {paragraph_id}")
 
-    for field, value in paragraph_in.model_dump(exclude_unset=True).items():
+    for field, value in paragraph_in.model_dump(exclude_none=True).items():
         setattr(paragraph, field, value)
 
     return datapublic_paragraph_create(paragraph, session)
@@ -95,7 +95,7 @@ def datapublic_paragraph_batch_create_update(
         if paragraph:
             update = DataPublicParagraphUpdate(**paragraph_in.model_dump())
 
-            for field, value in update.model_dump(exclude_unset=True).items():
+            for field, value in update.model_dump(exclude_none=True).items():
                 setattr(paragraph, field, value)
 
         else:


### PR DESCRIPTION
Update model_dump calls to use `exclude_none` instead of `exclude_unset` for improved handling of optional fields in the data models.

Fixes #40