### PR TITLE
Jansaldo/issues-42-43

### DIFF
--- a/aymurai/api/endpoints/routers/misc/document_extract.py
+++ b/aymurai/api/endpoints/routers/misc/document_extract.py
@@ -4,6 +4,7 @@ from threading import Lock
 
 from fastapi import Depends, UploadFile
 from fastapi.routing import APIRouter
+from more_itertools import unique_justseen
 
 from aymurai.api.utils import get_pipeline_doc_extract
 from aymurai.database.utils import data_to_uuid
@@ -59,7 +60,7 @@ def plain_text_extractor(
     document_id = data_to_uuid(data)
     doc_text: str = get_element(processed[0], ["data", "doc.text"], "")
 
-    return Document(
-        document=[text.strip() for text in doc_text.split("\n") if text.strip()],
-        document_id=document_id,
-    )
+    document = [text.strip() for text in doc_text.split("\n") if text.strip()]
+    document = list(unique_justseen(document))
+
+    return Document(document=document, document_id=document_id)

--- a/aymurai/settings.py
+++ b/aymurai/settings.py
@@ -2,19 +2,12 @@ import os
 from pathlib import Path
 
 from dotenv import load_dotenv
-from pydantic_core import MultiHostUrl
-from typing_extensions import Annotated
 from pydantic_settings import BaseSettings
-from pydantic import FilePath, ConfigDict, UrlConstraints, field_validator
+from pydantic import FilePath, ConfigDict, field_validator
 
 import aymurai
 
 PARENT = Path(aymurai.__file__).parent
-
-SQLiteDNS = Annotated[
-    MultiHostUrl,
-    UrlConstraints(host_required=False, allowed_schemes=["sqlite"]),
-]
 
 
 def load_env():
@@ -53,7 +46,7 @@ class Settings(BaseSettings):
 
         return [i.strip() for i in v.split(",")]
 
-    SQLALCHEMY_DATABASE_URI: SQLiteDNS = "sqlite:////resources/cache/sqlite/database.db"
+    SQLALCHEMY_DATABASE_URI: str = "sqlite:////resources/cache/sqlite/database.db"
 
     RESOURCES_BASEPATH: str = "/resources"
 


### PR DESCRIPTION
This pull request includes changes to improve the handling of document extraction and simplify the settings configuration. The most important changes include the addition of a new import for unique processing of document lines, the modification of the document extraction function to remove duplicate lines, and the simplification of the settings file by removing unused imports and annotations.

Improvements to document extraction:

* [`aymurai/api/endpoints/routers/misc/document_extract.py`](diffhunk://#diff-67c1dba6a66289ad2ec814d3a34a0486a16348ae727c9d664cfd1b59711e3fe4R7): Added `unique_justseen` from `more_itertools` to filter out consecutive duplicate lines in the document extraction process.
* [`aymurai/api/endpoints/routers/misc/document_extract.py`](diffhunk://#diff-67c1dba6a66289ad2ec814d3a34a0486a16348ae727c9d664cfd1b59711e3fe4L62-R66): Modified the `plain_text_extractor` function to use `unique_justseen` for removing consecutive duplicate lines from the document.

Simplification of settings configuration:

* [`aymurai/settings.py`](diffhunk://#diff-5a86713ba5e1a3a8dbadafc4de0e3dc702e8074621e605b215df7e799ba0b86dL5-L18): Removed unused imports and annotations, including `MultiHostUrl`, `Annotated`, and `UrlConstraints`.
* [`aymurai/settings.py`](diffhunk://#diff-5a86713ba5e1a3a8dbadafc4de0e3dc702e8074621e605b215df7e799ba0b86dL56-R49): Changed the type of `SQLALCHEMY_DATABASE_URI` from `SQLiteDNS` to `str`.

Fixes [#42](https://github.com/AymurAI/backend/issues/42) and [#43](https://github.com/AymurAI/backend/issues/43).