### PR TITLE
🐛 bugfix: Fix whitespace in extracted PDF paragraphs

### DIFF
--- a/aymurai/api/endpoints/routers/misc/document_extract.py
+++ b/aymurai/api/endpoints/routers/misc/document_extract.py
@@ -1,4 +1,5 @@
 import os
+import re
 import tempfile
 from threading import Lock
 
@@ -61,6 +62,7 @@ def plain_text_extractor(
     doc_text: str = get_element(processed[0], ["data", "doc.text"], "")
 
     document = [text.strip() for text in doc_text.split("\n") if text.strip()]
+    document = [re.sub(r"\s{2,}", "", text) for text in document]
     document = list(unique_justseen(document))
 
     return Document(document=document, document_id=document_id)

--- a/aymurai/api/endpoints/routers/misc/document_extract.py
+++ b/aymurai/api/endpoints/routers/misc/document_extract.py
@@ -62,7 +62,7 @@ def plain_text_extractor(
     doc_text: str = get_element(processed[0], ["data", "doc.text"], "")
 
     document = [text.strip() for text in doc_text.split("\n") if text.strip()]
-    document = [re.sub(r"\s{2,}", "", text) for text in document]
+    document = [re.sub(r"\s{2,}", " ", text) for text in document]
     document = list(unique_justseen(document))
 
     return Document(document=document, document_id=document_id)

--- a/aymurai/text/extraction.py
+++ b/aymurai/text/extraction.py
@@ -205,7 +205,6 @@ def pdf_to_text(filename: str, y_tolerance: float | None = None) -> str:
         y_tolerance = compute_median_margin_between_blocks(filename)
 
     paragraphs = extract_and_merge_paragraphs(filename, np.ceil(y_tolerance))
-    paragraphs = [re.sub(r"\s+", " ", paragraph).strip() for paragraph in paragraphs]
     docu = "\n\n".join(paragraphs)
     docu = unicodedata.normalize("NFKC", docu)
     return docu

--- a/aymurai/text/extraction.py
+++ b/aymurai/text/extraction.py
@@ -205,6 +205,7 @@ def pdf_to_text(filename: str, y_tolerance: float | None = None) -> str:
         y_tolerance = compute_median_margin_between_blocks(filename)
 
     paragraphs = extract_and_merge_paragraphs(filename, np.ceil(y_tolerance))
+    paragraphs = [re.sub(r"\s+", " ", paragraph).strip() for paragraph in paragraphs]
     docu = "\n\n".join(paragraphs)
     docu = unicodedata.normalize("NFKC", docu)
     return docu


### PR DESCRIPTION
Cleaned up whitespace in extracted paragraphs from PDF to ensure consistent formatting.

Fixes #47