### PR TITLE
XML Special Character Handling Fix in DocAnonymizer

### DIFF
--- a/aymurai/text/anonymization.py
+++ b/aymurai/text/anonymization.py
@@ -1,23 +1,23 @@
 import os
 import re
-import zipfile
 import tempfile
-from glob import glob
 import xml.sax.saxutils
+import zipfile
 from copy import deepcopy
+from glob import glob
 from unicodedata import normalize
 
 import numpy as np
 import pandas as pd
 from jiwer import cer
-from lxml import etree
 from joblib import hash
+from lxml import etree
 from more_itertools import flatten
 
 from aymurai.logger import get_logger
 from aymurai.meta.pipeline_interfaces import Transform
 from aymurai.models.flair.utils import FlairTextNormalize
-from aymurai.utils.alignment.core import tokenize, align_text
+from aymurai.utils.alignment.core import align_text, tokenize
 from aymurai.utils.cache import cache_load, cache_save, get_cache_key
 
 logger = get_logger(__file__)
@@ -293,9 +293,7 @@ class DocAnonymizer(Transform):
             len_text_to_replace = end_char - start_char
 
             # Replace the text with the anonymized token
-            aymurai_label = xml.sax.saxutils.escape(
-                f" <{unified_label['aymurai_label']}>"
-            )
+            aymurai_label = f" <{unified_label['aymurai_label']}>"
             len_aymurai_label = len(aymurai_label)
 
             doc = doc[:start_char] + aymurai_label + doc[end_char:]
@@ -487,6 +485,9 @@ class DocAnonymizer(Transform):
 
                     target = r["target"]
                     target = re.sub(r"[^\S\r\n]+", " ", target)
+
+                    # Escape XML special characters
+                    target = xml.sax.saxutils.escape(target)
 
                     content = content[:start_char] + target + content[end_char:]
 


### PR DESCRIPTION
This pull request fixes an important issue with XML special character handling in the `aymurai/text/anonymization.py` file to prevent XML parsing errors.

## Key Changes

### XML handling improvements:

* Removed the use of `xml.sax.saxutils.escape` in the `replace_labels_in_text` method when creating anonymized tokens, as escaping was deemed unnecessary in this context.
* Added XML escaping using `xml.sax.saxutils.escape` in the `replace_text_in_xml` method to ensure that special characters in the `target` text are properly escaped.
* This prevents XML parsing errors when anonymized text contains special characters.

### Code Organization Improvements

* Reordered imports in `aymurai/text/anonymization.py` to follow a more logical structure, grouping standard library, third-party, and local imports appropriately.
* Improved code readability through consistent formatting.

## Summary by Sourcery

Improve XML special character handling in the anonymization module and tidy code organization

Bug Fixes:
- Remove unnecessary XML escaping in label replacement to prevent double-escaping issues
- Add proper XML escaping in text replacement to avoid parsing errors with special characters

Enhancements:
- Reorder and group imports and apply consistent formatting for better readability