### PR TITLE
Fix/extraction magic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,18 +4,17 @@ include .env.common
 export $(shell sed 's/=.*//' .env.common)
 
 
-
 api-build:
-	docker compose build aymurai-api-dev
+	docker compose build aymurai-api
 api-run:
-	docker compose run --service-ports aymurai-api-dev
+	docker compose run --service-ports aymurai-api
 api-pull:
 	docker compose pull aymurai-api
 
 api-full-build:
 	docker compose build aymurai-api-full
 api-full-run:
-	docker compose run aymurai-api-full
+	docker compose run --service-ports aymurai-api-full
 api-full-pull:
 	docker compose pull aymurai-api-full
 

--- a/aymurai/api/endpoints/routers/misc/document_extract.py
+++ b/aymurai/api/endpoints/routers/misc/document_extract.py
@@ -1,19 +1,18 @@
+import concurrent.futures
 import os
 import re
 import tempfile
 
-from fastapi import UploadFile, HTTPException
-from starlette import status
+from fastapi import HTTPException, UploadFile
 from fastapi.routing import APIRouter
 from more_itertools import unique_justseen
+from starlette import status
 
 from aymurai.database.utils import data_to_uuid
 from aymurai.logger import get_logger
 from aymurai.meta.api_interfaces import Document
-from aymurai.text.extraction import MIMETYPE_EXTENSION_MAPPER
-from aymurai.text.extraction import extract_document
+from aymurai.text.extraction import MIMETYPE_EXTENSION_MAPPER, extract_document
 from aymurai.text.normalize import document_normalize
-import concurrent.futures
 
 logger = get_logger(__name__)
 
@@ -29,15 +28,18 @@ def extraction(path: str) -> str:
     return document_normalize(text) if text else ""
 
 
-def run_safe_text_extraction(path: str, timeout_s: float = 5) -> str:
+def run_safe_text_extraction(path: str, timeout_s: float = 30) -> str:
     """
     Runs the text extraction in a separate process to avoid blocking the main thread.
     This is useful for long-running tasks or when the extraction might hang.
+
     Args:
         path (str): Path to the file to be processed.
-        timeout_s (float): Timeout in seconds for the extraction process.
+        timeout_s (float): Timeout in seconds for the extraction process. Defaults to 30 seconds.
+
     Returns:
         str: Extracted text from the document.
+
     Raises:
         TimeoutError: If the extraction process exceeds the specified timeout.
     """
@@ -71,7 +73,7 @@ def plain_text_extractor(file: UploadFile) -> Document:
 
             logger.info(f"saved temp file on local storage => {tmp_filename}")
 
-            document = run_safe_text_extraction(tmp_filename, timeout_s=5)
+            document = run_safe_text_extraction(tmp_filename)
 
         except concurrent.futures.TimeoutError:
             logger.error(f"Timeout while extracting text from {file.filename}")

--- a/aymurai/text/extraction.py
+++ b/aymurai/text/extraction.py
@@ -1,13 +1,13 @@
-import os
 import logging
-import zipfile
+import mimetypes
+import os
 import statistics
 import unicodedata
+import zipfile
 from pathlib import Path
 from typing import Any
 from zipfile import BadZipFile
 
-import magic
 import numpy as np
 import pymupdf
 import textract
@@ -18,8 +18,6 @@ from textract.exceptions import ShellError
 from textract.parsers import _get_available_extensions
 
 from aymurai.logger import get_logger
-from aymurai.meta.pipeline_interfaces import Transform
-from aymurai.utils.cache import cache_load, cache_save, get_cache_key
 from aymurai.utils.misc import get_element, get_recursively
 
 logger = get_logger(__file__)
@@ -43,8 +41,43 @@ class InvalidFile(Exception):
 
 
 def get_extension(path: str) -> str:
-    mimetype = magic.from_file(path, mime=True)
-    return MIMETYPE_EXTENSION_MAPPER.get(mimetype, mimetype)
+    # First, try by extension
+    ext = os.path.splitext(path)[1].lower()
+
+    if ext == ".pdf":
+        # Quick PDF header check
+        with open(path, "rb") as f:
+            if f.read(4) == b"%PDF":
+                return "pdf"
+
+    if ext == ".docx":
+        # Check for docx structure (zip with word/document.xml)
+        try:
+            with zipfile.ZipFile(path, "r") as z:
+                if "word/document.xml" in z.namelist():
+                    return "docx"
+        except Exception:
+            pass
+
+    if ext == ".odt":
+        # Check for odt structure (zip with content.xml)
+        try:
+            with zipfile.ZipFile(path, "r") as z:
+                if "content.xml" in z.namelist():
+                    return "odt"
+        except Exception:
+            pass
+
+    # Fallback to mimetypes
+    mimetype, _ = mimetypes.guess_type(path)
+    if mimetype in MIMETYPE_EXTENSION_MAPPER:
+        return MIMETYPE_EXTENSION_MAPPER[mimetype]
+
+    # Fallback: return extension without dot
+    if ext:
+        return ext[1:]
+
+    return "unknown"
 
 
 def _load_xml_from_odt(path: str, xmlfile: str = "styles.xml") -> str:

--- a/aymurai/text/extraction.py
+++ b/aymurai/text/extraction.py
@@ -40,43 +40,63 @@ class InvalidFile(Exception):
     pass
 
 
+def _zip_contains(path: str, member: str) -> bool:
+    """
+    Check if a zip file contains a specific member.
+
+    Args:
+        path (str): Path to the zip file.
+        member (str): Member name to check for.
+
+    Returns:
+        bool: True if the member exists in the zip file, False otherwise.
+    """
+    try:
+        with zipfile.ZipFile(path, "r") as archive:
+            return member in archive.namelist()
+
+    except (FileNotFoundError, PermissionError, OSError) as exc:
+        logger.warning("Cannot access '%s': %s", path, exc)
+
+    except BadZipFile as exc:
+        logger.warning("Invalid zip structure for '%s': %s", path, exc)
+
+    return False
+
+
 def get_extension(path: str) -> str:
     # First, try by extension
     ext = os.path.splitext(path)[1].lower()
 
     if ext == ".pdf":
-        # Quick PDF header check
-        with open(path, "rb") as f:
-            if f.read(4) == b"%PDF":
+        try:
+            with open(path, "rb") as file_handle:
+                header = file_handle.read(1024)
+
+        except (FileNotFoundError, PermissionError, OSError) as exc:
+            logger.warning("Cannot open '%s': %s", path, exc)
+
+        else:
+            # PDF header check: scan for %PDF within the first 1KB
+            if b"%PDF" in header:
                 return "pdf"
 
-    if ext == ".docx":
-        # Check for docx structure (zip with word/document.xml)
-        try:
-            with zipfile.ZipFile(path, "r") as z:
-                if "word/document.xml" in z.namelist():
-                    return "docx"
-        except Exception:
-            pass
+    if ext == ".docx" and _zip_contains(path, "word/document.xml"):
+        return "docx"
 
-    if ext == ".odt":
-        # Check for odt structure (zip with content.xml)
-        try:
-            with zipfile.ZipFile(path, "r") as z:
-                if "content.xml" in z.namelist():
-                    return "odt"
-        except Exception:
-            pass
+    if ext == ".odt" and _zip_contains(path, "content.xml"):
+        return "odt"
 
     # Fallback to mimetypes
     mimetype, _ = mimetypes.guess_type(path)
     if mimetype in MIMETYPE_EXTENSION_MAPPER:
         return MIMETYPE_EXTENSION_MAPPER[mimetype]
 
-    # Fallback: return extension without dot
     if ext:
+        logger.debug("Falling back to raw extension for '%s'", path)
         return ext[1:]
 
+    logger.warning("Unable to identify file type for '%s'", path)
     return "unknown"
 
 

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -1,7 +1,7 @@
 # -------------------
 # Build Stage
 # -------------------
-FROM python:3.10-slim AS builder
+FROM python:3.10-slim-bullseye AS builder
 
 # Install Git
 RUN apt-get update && \
@@ -35,7 +35,7 @@ RUN --mount=type=bind,source=.git,target=.git \
 # -------------------
 # Base API Stage
 # -------------------
-FROM python:3.10-slim AS aymurai-api
+FROM python:3.10-slim-bullseye AS aymurai-api
 
 # Set environment variables
 ENV LANG=C.UTF-8 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ dependencies = [
     # "scikit-learn==1.5.2",
     "jiwer==3.0.5",
     "datasets>=3.2.0",
-    "python-magic==0.4.27",
     "unidecode==1.3.8",
     "sentencepiece==0.2.0",
     # "flair @ git+https://github.com/flairNLP/flair@v0.13.1",

--- a/uv.lock
+++ b/uv.lock
@@ -238,7 +238,7 @@ wheels = [
 
 [[package]]
 name = "aymurai"
-version = "1.1.11"
+version = "1.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
@@ -263,7 +263,6 @@ dependencies = [
     { name = "pypandoc" },
     { name = "python-docx" },
     { name = "python-dotenv" },
-    { name = "python-magic" },
     { name = "python-multipart" },
     { name = "pytorch-lightning" },
     { name = "requests" },
@@ -317,7 +316,6 @@ requires-dist = [
     { name = "pypandoc", specifier = ">=1.15" },
     { name = "python-docx", specifier = ">=1.2.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
-    { name = "python-magic", specifier = "==0.4.27" },
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "pytorch-lightning", specifier = "==1.8.3.post1" },
     { name = "requests", specifier = ">=2.32.3" },
@@ -2541,15 +2539,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e3/c4/358cd13daa1d912ef795010897a483ab2f0b41c9ea1b35235a8b2f7d15a7/python_json_logger-3.2.1.tar.gz", hash = "sha256:8eb0554ea17cb75b05d2848bc14fb02fbdbd9d6972120781b974380bfa162008", size = 16287 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/72/2f30cf26664fcfa0bd8ec5ee62ec90c03bd485e4a294d92aabc76c5203a5/python_json_logger-3.2.1-py3-none-any.whl", hash = "sha256:cdc17047eb5374bd311e748b42f99d71223f3b0e186f4206cc5d52aefe85b090", size = 14924 },
-]
-
-[[package]]
-name = "python-magic"
-version = "0.4.27"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/da/db/0b3e28ac047452d079d375ec6798bf76a036a08182dbb39ed38116a49130/python-magic-0.4.27.tar.gz", hash = "sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b", size = 14677 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/73/9f872cb81fc5c3bb48f7227872c28975f998f3e7c2b1c16e95e6432bbb90/python_magic-0.4.27-py2.py3-none-any.whl", hash = "sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3", size = 13840 },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request primarily refactors how file type detection is handled in the `aymurai/text/extraction.py` module, removing the dependency on the `python-magic` library and improving extension-based detection. Additionally, it updates Docker images to use the `bullseye` variant for improved compatibility and consistency, and adjusts related Makefile targets. Below are the most important changes:

**File Type Detection Refactor:**

* Rewrote the `get_extension` function in `aymurai/text/extraction.py` to detect file types based on file extension and content rather than relying on the `magic` library. This includes specific checks for PDF, DOCX, and ODT formats, with a fallback to the `mimetypes` module and extension-based detection.
* Removed the import and dependency on `python-magic` from both the codebase and the `pyproject.toml` dependencies. [[1]](diffhunk://#diff-fb8b28032610467891ae3afff75464398d52e3e34ef2e816c553cb6ccdbfebf9L1-L10) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L65)

**Docker and Build System Updates:**

* Updated the base Docker images in `docker/api/Dockerfile` to use the `python:3.10-slim-bullseye` variant for both the build and API stages, improving compatibility and consistency. [[1]](diffhunk://#diff-a25b16b314f28dda606334a58d7b15a86b61ef2b1c56222c94aba7c6d5df217cL4-R4) [[2]](diffhunk://#diff-a25b16b314f28dda606334a58d7b15a86b61ef2b1c56222c94aba7c6d5df217cL38-R38)
* Updated Makefile targets to use the correct service names (`aymurai-api` instead of `aymurai-api-dev`) and ensured `--service-ports` is consistently used where needed.

**Code Cleanup:**

* Removed unused imports related to caching and pipeline interfaces in `aymurai/text/extraction.py`.

## Summary by Sourcery

Refactor file type detection in extraction.py to eliminate python-magic and rely on extension and content checks, remove the python-magic dependency, bump Docker images to the bullseye variant, and update Makefile targets to use the correct service names and service ports.

Enhancements:
- Refactor file type detection in extraction.py to use extension and content checks instead of python-magic
- Remove unused imports and drop python-magic dependency from pyproject.toml

Build:
- Update Docker base images to python:3.10-slim-bullseye for both builder and API stages

Chores:
- Adjust Makefile targets to use correct service names (aymurai-api) and include --service-ports