### PR TITLE
Fix/tag api version

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -23,12 +23,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Step 3: Extract the tag name from the Git reference
-      - name: Extract tag name
-        id: tag
-        run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-
-      # Step 4: Build and push the Docker images
+      # Step 3: Build and push the Docker images
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -37,9 +32,9 @@ jobs:
           push: true
           target: aymurai-api
           build-args: |
-            SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.tag.outputs.TAG }}
+            SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.ref_name }}
           tags: |
-            ghcr.io/aymurai/api:${{ steps.tag.outputs.TAG }}
+            ghcr.io/aymurai/api:${{ github.ref_name }}
             ghcr.io/aymurai/api:latest
 
       - name: Build and push Docker full image
@@ -50,7 +45,7 @@ jobs:
           push: true
           target: aymurai-api-full
           build-args: |
-            SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.tag.outputs.TAG }}
+            SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.ref_name }}
           tags: |
-            ghcr.io/aymurai/api:full-${{ steps.tag.outputs.TAG }}
+            ghcr.io/aymurai/api:full-${{ github.ref_name }}
             ghcr.io/aymurai/api:full

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -23,7 +23,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Step 3: Build and push the Docker images
+      # Step 3: Extract the tag name from the Git reference
+      - name: Extract tag name
+        id: tag
+        run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      # Step 4: Build and push the Docker images
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -32,9 +37,9 @@ jobs:
           push: true
           target: aymurai-api
           build-args: |
-            SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.ref_name }}
+            SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.tag.outputs.TAG }}
           tags: |
-            ghcr.io/aymurai/api:${{ github.ref_name }}
+            ghcr.io/aymurai/api:${{ steps.tag.outputs.TAG }}
             ghcr.io/aymurai/api:latest
 
       - name: Build and push Docker full image
@@ -45,7 +50,7 @@ jobs:
           push: true
           target: aymurai-api-full
           build-args: |
-            SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.ref_name }}
+            SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.tag.outputs.TAG }}
           tags: |
-            ghcr.io/aymurai/api:full-${{ github.ref_name }}
+            ghcr.io/aymurai/api:full-${{ steps.tag.outputs.TAG }}
             ghcr.io/aymurai/api:full

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -26,7 +26,12 @@ jobs:
       # Step 3: Extract the tag name from the Git reference
       - name: Extract tag name
         id: tag
-        run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          if [[ -z "$TAG" || "$TAG" == "$GITHUB_REF" ]]; then
+            TAG="dev-${GITHUB_SHA::7}"
+          fi
+          echo "TAG=$TAG" >> $GITHUB_OUTPUT
 
       # Step 4: Build and push the Docker images
       - name: Build and push Docker image

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -23,7 +23,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Step 3: Build and push the Docker images
+      # Step 3: Extract the tag name from the Git reference
+      - name: Extract tag name
+        id: tag
+        run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      # Step 4: Build and push the Docker images
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -23,22 +23,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Step 3: Build the Docker image
-      - name: Build Docker Image
-        run: |
-          touch .env
-          docker compose build aymurai-api
-          docker compose build aymurai-api-full
+      # Step 3: Build and push the Docker images
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/api/Dockerfile
+          push: true
+          target: aymurai-api
+          build-args: |
+            SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.tag.outputs.TAG }}
+          tags: |
+            ghcr.io/aymurai/api:${{ steps.tag.outputs.TAG }}
+            ghcr.io/aymurai/api:latest
 
-      # Step 4: Push the Docker image to GHCR
-      - name: Push Docker Image
-        run: |
-          docker tag ghcr.io/aymurai/api:latest ghcr.io/aymurai/api:${{ github.ref_name }}
-          docker tag ghcr.io/aymurai/api:full ghcr.io/aymurai/api:full-${{ github.ref_name }}
-
-          docker push ghcr.io/aymurai/api:full-${{ github.ref_name }}
-          docker push ghcr.io/aymurai/api:${{ github.ref_name }}
-          if [[ "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            docker push ghcr.io/aymurai/api:latest
-            docker push ghcr.io/aymurai/api:full
-          fi
+      - name: Build and push Docker full image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/api/Dockerfile
+          push: true
+          target: aymurai-api-full
+          build-args: |
+            SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.tag.outputs.TAG }}
+          tags: |
+            ghcr.io/aymurai/api:full-${{ steps.tag.outputs.TAG }}
+            ghcr.io/aymurai/api:full

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -25,6 +25,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY aymurai /app/aymurai
 
 # Finalize package installation
+ARG SETUPTOOLS_SCM_PRETEND_VERSION
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION}
 RUN --mount=type=bind,source=.git,target=.git \
     --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \


### PR DESCRIPTION
This pull request updates the Docker build and deployment process to improve automation and version tagging. The workflow now uses the `docker/build-push-action` for building and pushing images, and introduces a build argument to ensure version consistency in the Docker image.

**CI/CD workflow improvements:**

* Replaces manual Docker build and push steps in `.github/workflows/build-docker-image.yml` with the `docker/build-push-action`, streamlining the process and ensuring images are built and pushed in a more standard and reliable way.
* Adds a step to extract the tag name from the Git reference and uses it to tag Docker images, ensuring that images are consistently and correctly versioned.

**Docker image versioning:**

* Adds the `SETUPTOOLS_SCM_PRETEND_VERSION` build argument and environment variable in `docker/api/Dockerfile`, allowing the built image to reflect the correct version based on the Git tag.

## Summary by Sourcery

Streamline Docker image building and tagging by replacing manual build steps with the docker/build-push-action in the CI workflow and introducing a build argument for consistent versioning in the Docker image.

Enhancements:
- Introduce SETUPTOOLS_SCM_PRETEND_VERSION build argument and environment variable in the Dockerfile for accurate version embedding

CI:
- Replace manual Docker build and push steps with docker/build-push-action for both standard and full API images
- Add workflow step to extract Git tag from the reference and use it to tag Docker images