### PR TITLE
Feature/ollama service

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,8 @@
             ],
             "subProcess": false,
             "envFile": "${workspaceFolder}/.env",
-            "python": "${workspaceFolder}/.venv/bin/python"
+            "python": "${workspaceFolder}/.venv/bin/python",
+            "preLaunchTask": "Start Ollama service"
         },
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Start Ollama service",
+            "type": "shell",
+            "command": "make",
+            "args": [
+                "ollama-up"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": []
+        }
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,40 @@ api-full-run:
 api-full-pull:
 	docker compose pull aymurai-api-full
 
+ollama-up:
+	docker compose up -d --no-recreate ollama
+
+ollama-stop:
+	docker compose stop ollama
+
+ollama-restart:
+	docker compose restart ollama
+
+ollama-pull:
+ifndef MODEL
+	$(error MODEL variable is required, e.g. make ollama-pull MODEL=llama3)
+endif
+	docker compose up -d --no-recreate ollama
+	docker compose exec ollama ollama pull $(MODEL)
+
+ollama-run:
+ifndef MODEL
+	$(error MODEL variable is required, e.g. make ollama-run MODEL=llama3)
+endif
+	docker compose up -d --no-recreate ollama
+	docker compose exec -it ollama ollama run $(MODEL)
+
+ollama-list:
+	docker compose up -d --no-recreate ollama
+	docker compose exec ollama ollama list
+
+ollama-rm:
+ifndef MODEL
+	$(error MODEL variable is required, e.g. make ollama-rm MODEL=llama3)
+endif
+	docker compose up -d --no-recreate ollama
+	docker compose exec ollama ollama rm $(MODEL)
+
 stress-test:
 	locust -f locustfile.py --host http://localhost:8899
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
         image: ghcr.io/aymurai/api:latest
         ports:
             - "8899:8899"
+        depends_on:
+            - ollama
         build:
             context: .
             dockerfile: ./docker/api/Dockerfile
@@ -17,6 +19,8 @@ services:
         image: ghcr.io/aymurai/api:full
         ports:
             - "8899:8899"
+        depends_on:
+            - ollama
         build:
             context: .
             dockerfile: ./docker/api/Dockerfile
@@ -27,3 +31,22 @@ services:
                 limits:
                     memory: 4g
                     cpus: "4.0"
+
+    ollama:
+        image: ollama/ollama
+        container_name: ollama
+        deploy:
+            resources:
+                reservations:
+                    devices:
+                        - driver: nvidia
+                          count: all
+                          capabilities: [gpu]
+        ports:
+            - "11434:11434"
+        volumes:
+            - ollama:/root/.ollama
+        restart: always
+
+volumes:
+    ollama:


### PR DESCRIPTION
This pull request adds support for managing an Ollama service as part of the development and deployment workflow. The changes introduce a new Ollama container to the Docker Compose setup, provide Makefile commands for common Ollama operations, and integrate Ollama startup into the VSCode development environment.

**Docker and service integration:**

* Added an `ollama` service to `docker-compose.yml` with GPU support, persistent storage, and automatic restart, and made API services depend on it to ensure proper startup order. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R6-R7) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R22-R23) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R34-R52)

**Developer tooling and automation:**

* Introduced multiple Makefile targets for managing the Ollama service and models (start, stop, restart, pull, run, list, and remove), streamlining development and model management workflows.
* Added a VSCode task (`tasks.json`) to start the Ollama service using the new Makefile command, and configured the Python launch configuration to run this task before debugging. [[1]](diffhunk://#diff-7d76d7533653c23b753fc7ce638cf64bdb5e419927d276af836d3a03fdf1745aR1-R19) [[2]](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945L22-R23)

## Summary by Sourcery

Integrate an Ollama service into the development workflow by adding it to Docker Compose, providing Makefile commands for model management, and automating its startup in VSCode.

New Features:
- Add Ollama service to docker-compose.yml with GPU support, persistent storage, and restart policy
- Introduce Makefile targets for starting, stopping, restarting, and managing Ollama models (pull, run, list, remove)
- Configure VSCode tasks and pre-launch setup to automatically start the Ollama service before debugging