### PR TITLE
feat(asr): add per-document speaker name persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,9 @@ resources
 .venv
 
 aymurai/version.py
+
+# Git worktrees
+.worktrees/
+
+# Local-only superpowers specs and plans (never committed)
+docs/superpowers/

--- a/aymurai/api/endpoints/routers/asr/transcribe.py
+++ b/aymurai/api/endpoints/routers/asr/transcribe.py
@@ -160,6 +160,7 @@ async def asr_read_document_validation(
     return ASRDocument(
         document_id=document_id,
         document=record.validation or record.transcription,
+        speaker_names=record.speaker_names or {},
     )
 
 

--- a/aymurai/api/endpoints/routers/asr/transcribe.py
+++ b/aymurai/api/endpoints/routers/asr/transcribe.py
@@ -17,7 +17,11 @@ from aymurai.database.crud.audio_transcription import (
 from aymurai.database.session import get_session
 from aymurai.database.utils import data_to_uuid
 from aymurai.logger import get_logger
-from aymurai.meta.api_interfaces import ASRDocument, ASRParagraph, ASRParagraphRequest
+from aymurai.meta.api_interfaces import (
+    ASRDocument,
+    ASRParagraph,
+    ASRValidationRequest,
+)
 from aymurai.settings import settings
 
 router = APIRouter()
@@ -162,15 +166,18 @@ async def asr_read_document_validation(
 @router.post("/validation/document/{document_id}")
 async def asr_save_document_validation(
     document_id: UUID5,
-    annotations: list[ASRParagraphRequest] = Body(...),
+    payload: ASRValidationRequest = Body(...),
     session: Session = Depends(get_session),
 ) -> None:
     """
-    Saves the validation annotations for a given document ID.
+    Saves the validation annotations and optional speaker names for a document.
 
     Args:
         document_id (UUID5): The ID of the document to validate.
-        annotations (list[ASRParagraphRequest], optional): The list of annotations for the document. Defaults to Body(...).
+        payload (ASRValidationRequest): Body containing ``annotations`` and
+            optional ``speaker_names``. When ``speaker_names`` is ``None`` the
+            stored map is preserved; when present (including ``{}``) it fully
+            replaces the stored map.
         session (Session, optional): The database session. Defaults to Depends(get_session).
 
     Raises:
@@ -183,8 +190,11 @@ async def asr_save_document_validation(
     # NOTE: we are serializing the paragraphs to JSON for writing to the DB
     record.validation = [  # type: ignore
         ASRParagraph.model_validate(item).model_dump(mode="json")
-        for item in annotations
+        for item in payload.annotations
     ]
+
+    if payload.speaker_names is not None:
+        record.speaker_names = payload.speaker_names
 
     session.add(record)
     session.commit()

--- a/aymurai/database/crud/audio_transcription.py
+++ b/aymurai/database/crud/audio_transcription.py
@@ -28,6 +28,7 @@ def audio_transcription_create_or_update(
     name: str,
     transcription: list[ASRParagraph],
     session: Session,
+    speaker_names: dict[str, str] | None = None,
 ) -> AudioTranscription:
     """
     Create or update an audio transcription record.
@@ -37,6 +38,9 @@ def audio_transcription_create_or_update(
         name (str): Name of the transcription.
         transcription (list[ASRParagraph]): List of ASRParagraph objects representing the transcription.
         session (Session): SQLAlchemy session.
+        speaker_names (dict[str, str] | None, optional): Mapping of speaker index (as str) to user-provided name.
+            When None, the existing value is preserved on updates (defaults to empty dict on create).
+            When provided (including an empty dict), replaces the stored value.
 
     Returns:
         AudioTranscription: The created or updated AudioTranscription record.
@@ -52,11 +56,14 @@ def audio_transcription_create_or_update(
             name=name,
             transcription=serialized_transcription,
             validation=[],
+            speaker_names=speaker_names if speaker_names is not None else {},
         )
     else:
         record.name = name
         record.transcription = serialized_transcription
         record.validation = []
+        if speaker_names is not None:
+            record.speaker_names = speaker_names
 
     session.add(record)
     session.commit()

--- a/aymurai/database/meta/audio_transcription.py
+++ b/aymurai/database/meta/audio_transcription.py
@@ -18,6 +18,10 @@ class AudioTranscriptionBase(SQLModel):
         default_factory=list,
         sa_column=Column(JSON),
     )
+    speaker_names: dict[str, str] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON),
+    )
 
 
 class AudioTranscription(AudioTranscriptionBase, table=True):
@@ -39,6 +43,7 @@ class AudioTranscriptionUpdate(SQLModel):
     name: str | None = None
     transcription: list[ASRParagraph] | None = None
     validation: list[ASRParagraph] | None = None
+    speaker_names: dict[str, str] | None = None
 
 
 class AudioTranscriptionRead(AudioTranscriptionBase):

--- a/aymurai/database/versions/56103c9aa43c_add_speaker_names_to_audio_transcription.py
+++ b/aymurai/database/versions/56103c9aa43c_add_speaker_names_to_audio_transcription.py
@@ -1,0 +1,35 @@
+"""add speaker_names to audio_transcription
+
+Revision ID: 56103c9aa43c
+Revises: 49b3f24f7ad0
+Create Date: 2026-04-21 14:01:04.905492
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "56103c9aa43c"
+down_revision: Union[str, None] = "49b3f24f7ad0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "audio_transcription",
+        sa.Column(
+            "speaker_names",
+            sa.JSON(),
+            nullable=False,
+            server_default=sa.text("'{}'"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("audio_transcription", "speaker_names")

--- a/aymurai/meta/api_interfaces.py
+++ b/aymurai/meta/api_interfaces.py
@@ -129,9 +129,31 @@ class ASRParagraphRequest(BaseModel):
     text: str
 
 
+class ASRValidationRequest(BaseModel):
+    """Request body for POST /asr/validation/document/{id}.
+
+    Carries both the corrected paragraph annotations and the optional speaker
+    name map. Replaces the previous bare-list request format.
+    """
+
+    annotations: list[ASRParagraphRequest]
+    speaker_names: dict[str, str] | None = Field(
+        default=None,
+        description=(
+            "Mapping of speaker index (as string) to user-provided name. "
+            "None keeps the existing value; {} clears all names; a non-empty "
+            "dict fully replaces the stored map."
+        ),
+    )
+
+
 class ASRDocument(BaseModel):
     document: list[ASRParagraph]
     document_id: UUID
+    speaker_names: dict[str, str] = Field(
+        default_factory=dict,
+        description="Mapping of speaker index (as string) to user-provided name.",
+    )
 
     def to_txt(self) -> str:
         return "\n\n".join([paragraph.to_txt() for paragraph in self.document])
@@ -141,6 +163,7 @@ class ASRDocument(BaseModel):
         return cls(
             document=transcription.validation or transcription.transcription,
             document_id=transcription.id,
+            speaker_names=transcription.speaker_names or {},
         )
 
 

--- a/test/api/endpoints/routers/asr/test_transcribe.py
+++ b/test/api/endpoints/routers/asr/test_transcribe.py
@@ -290,3 +290,78 @@ def test_should_clear_speaker_names_when_posting_empty_map(
         record = session.get(AudioTranscription, document_id)
         assert record is not None
         assert record.speaker_names == {}
+
+
+# MARK: GET Validation with speaker_names
+def test_should_include_speaker_names_in_get_validation_response(
+    asr_test_client,
+    make_wav_bytes,
+):
+    client, engine = asr_test_client
+    audio_bytes = make_wav_bytes(freq_hz=770)
+    document_id = data_to_uuid(audio_bytes)
+
+    with Session(engine) as session:
+        session.add(
+            AudioTranscription(
+                id=document_id,
+                name="get_speakers.wav",
+                transcription=cast(
+                    Any,
+                    [
+                        ASRParagraph(
+                            speaker_no=0,
+                            start=timedelta(seconds=0),
+                            end=timedelta(seconds=1),
+                            text="Saludo",
+                        ).model_dump(mode="json")
+                    ],
+                ),
+                validation=[],
+                speaker_names={"0": "Jueza", "1": "Defensor"},
+            )
+        )
+        session.commit()
+
+    response = client.get(f"/asr/validation/document/{document_id}")
+
+    assert response.status_code == 200
+    payload = ASRDocument.model_validate(response.json())
+    assert payload.speaker_names == {"0": "Jueza", "1": "Defensor"}
+
+
+def test_should_return_empty_speaker_names_when_none_stored(
+    asr_test_client,
+    make_wav_bytes,
+):
+    client, engine = asr_test_client
+    audio_bytes = make_wav_bytes(freq_hz=880)
+    document_id = data_to_uuid(audio_bytes)
+
+    with Session(engine) as session:
+        session.add(
+            AudioTranscription(
+                id=document_id,
+                name="empty_speakers.wav",
+                transcription=cast(
+                    Any,
+                    [
+                        ASRParagraph(
+                            speaker_no=0,
+                            start=timedelta(seconds=0),
+                            end=timedelta(seconds=1),
+                            text="x",
+                        ).model_dump(mode="json")
+                    ],
+                ),
+                validation=[],
+                speaker_names={},
+            )
+        )
+        session.commit()
+
+    response = client.get(f"/asr/validation/document/{document_id}")
+
+    assert response.status_code == 200
+    payload = ASRDocument.model_validate(response.json())
+    assert payload.speaker_names == {}

--- a/test/api/endpoints/routers/asr/test_transcribe.py
+++ b/test/api/endpoints/routers/asr/test_transcribe.py
@@ -141,8 +141,12 @@ def test_should_persist_validation_annotations_when_posting_validation_for_exist
         )
         session.commit()
 
-    annotations = [{"speaker_no": 1, "start": 0, "end": 1, "text": "Linea validada"}]
-    response = client.post(f"/asr/validation/document/{document_id}", json=annotations)
+    body = {
+        "annotations": [
+            {"speaker_no": 1, "start": 0, "end": 1, "text": "Linea validada"}
+        ]
+    }
+    response = client.post(f"/asr/validation/document/{document_id}", json=body)
 
     assert response.status_code == 200
     with Session(engine) as session:
@@ -150,3 +154,139 @@ def test_should_persist_validation_annotations_when_posting_validation_for_exist
         assert record is not None
         first_item = cast(dict[str, Any], record.validation[0])
         assert first_item["text"] == "Linea validada"
+
+
+# MARK: POST Validation with speaker_names
+def test_should_persist_speaker_names_when_posting_validation(
+    asr_test_client,
+    make_wav_bytes,
+):
+    client, engine = asr_test_client
+    audio_bytes = make_wav_bytes(freq_hz=440)
+    document_id = data_to_uuid(audio_bytes)
+
+    with Session(engine) as session:
+        session.add(
+            AudioTranscription(
+                id=document_id,
+                name="speakers.wav",
+                transcription=cast(
+                    Any,
+                    [
+                        ASRParagraph(
+                            speaker_no=0,
+                            start=timedelta(seconds=0),
+                            end=timedelta(seconds=1),
+                            text="Hola",
+                        ).model_dump(mode="json")
+                    ],
+                ),
+                validation=[],
+                speaker_names={},
+            )
+        )
+        session.commit()
+
+    body = {
+        "annotations": [
+            {"speaker_no": 0, "start": 0, "end": 1, "text": "Hola validada"}
+        ],
+        "speaker_names": {"0": "Jueza", "1": "Defensor"},
+    }
+    response = client.post(f"/asr/validation/document/{document_id}", json=body)
+
+    assert response.status_code == 200
+    with Session(engine) as session:
+        record = session.get(AudioTranscription, document_id)
+        assert record is not None
+        assert record.speaker_names == {"0": "Jueza", "1": "Defensor"}
+        first_item = cast(dict[str, Any], record.validation[0])
+        assert first_item["text"] == "Hola validada"
+
+
+def test_should_preserve_speaker_names_when_posting_validation_without_them(
+    asr_test_client,
+    make_wav_bytes,
+):
+    client, engine = asr_test_client
+    audio_bytes = make_wav_bytes(freq_hz=550)
+    document_id = data_to_uuid(audio_bytes)
+
+    with Session(engine) as session:
+        session.add(
+            AudioTranscription(
+                id=document_id,
+                name="preserve.wav",
+                transcription=cast(
+                    Any,
+                    [
+                        ASRParagraph(
+                            speaker_no=0,
+                            start=timedelta(seconds=0),
+                            end=timedelta(seconds=1),
+                            text="Base",
+                        ).model_dump(mode="json")
+                    ],
+                ),
+                validation=[],
+                speaker_names={"0": "Jueza"},
+            )
+        )
+        session.commit()
+
+    body = {
+        "annotations": [
+            {"speaker_no": 0, "start": 0, "end": 1, "text": "Base validada"}
+        ],
+        # speaker_names omitted → preserved
+    }
+    response = client.post(f"/asr/validation/document/{document_id}", json=body)
+
+    assert response.status_code == 200
+    with Session(engine) as session:
+        record = session.get(AudioTranscription, document_id)
+        assert record is not None
+        assert record.speaker_names == {"0": "Jueza"}
+
+
+def test_should_clear_speaker_names_when_posting_empty_map(
+    asr_test_client,
+    make_wav_bytes,
+):
+    client, engine = asr_test_client
+    audio_bytes = make_wav_bytes(freq_hz=660)
+    document_id = data_to_uuid(audio_bytes)
+
+    with Session(engine) as session:
+        session.add(
+            AudioTranscription(
+                id=document_id,
+                name="clear.wav",
+                transcription=cast(
+                    Any,
+                    [
+                        ASRParagraph(
+                            speaker_no=0,
+                            start=timedelta(seconds=0),
+                            end=timedelta(seconds=1),
+                            text="t",
+                        ).model_dump(mode="json")
+                    ],
+                ),
+                validation=[],
+                speaker_names={"0": "Jueza"},
+            )
+        )
+        session.commit()
+
+    body = {
+        "annotations": [{"speaker_no": 0, "start": 0, "end": 1, "text": "t"}],
+        "speaker_names": {},
+    }
+    response = client.post(f"/asr/validation/document/{document_id}", json=body)
+
+    assert response.status_code == 200
+    with Session(engine) as session:
+        record = session.get(AudioTranscription, document_id)
+        assert record is not None
+        assert record.speaker_names == {}


### PR DESCRIPTION
## Summary

- Adds `speaker_names: dict[str, str]` JSON column to the `audio_transcription` table (Alembic migration included; upgrade/downgrade verified)
- Wraps `POST /asr/validation/document/{id}` body in a new `ASRValidationRequest` schema `{annotations, speaker_names}` — **breaking change** from the previous bare-list body (acceptable for `release/v2.0.0`)
- `GET /asr/validation/document/{id}` now returns `speaker_names` in the `ASRDocument` response

## Behaviour

| `speaker_names` in POST body | Effect |
|---|---|
| omitted (`null`) | Existing map preserved |
| `{}` | Clears all names |
| `{"0": "Jueza", ...}` | Full replacement |

## Test Plan

- [x] 8/8 integration tests pass (`test/api/endpoints/routers/asr/`)
- [x] Alembic upgrade/downgrade verified against SQLite
- [x] `ruff format` + `ruff check` clean on all changed files

## Notes

- Migration uses `server_default=sa.text("'{}'")`  — correct for SQLite. If PostgreSQL support is added later, the cast should be updated to `::json`.
- Keys in `speaker_names` are strings by design (JSON object keys must be strings).

## Summary by Sourcery

Add per-document speaker name support to ASR validation, including persistence in the database and exposure via the ASR validation API.

New Features:
- Allow clients to provide and update per-speaker display names alongside ASR validation annotations via a new ASRValidationRequest payload.
- Expose persisted speaker name mappings on ASR validation read responses through the ASRDocument schema.

Enhancements:
- Extend audio transcription creation and update logic to manage optional speaker name maps while preserving existing values when omitted.

Tests:
- Add and update ASR endpoint integration tests to cover the new validation request shape and speaker name persistence and retrieval semantics.

Chores:
- Add an Alembic migration and model changes to store speaker name maps on audio_transcription records as a JSON column.