### PR TITLE
Fix handling of non-alphanumeric entities in cleaned text

### DIFF
--- a/aymurai/transforms/anonymization_postprocess/core.py
+++ b/aymurai/transforms/anonymization_postprocess/core.py
@@ -1,10 +1,9 @@
 import re
 from copy import deepcopy
-from string import punctuation
 
+from aymurai.meta.pipeline_interfaces import Transform
 from aymurai.meta.types import DataItem
 from aymurai.utils.misc import get_element
-from aymurai.meta.pipeline_interfaces import Transform
 
 
 class AnonymizationEntityCleaner(Transform):
@@ -45,6 +44,9 @@ class AnonymizationEntityCleaner(Transform):
         # Clean the text
         cleaned_text = pattern.sub("", original_text)
 
+        if not cleaned_text:
+            return None
+
         # Update the entity's alt text and indices
         ent["attrs"]["aymurai_alt_text"] = cleaned_text
         ent["attrs"]["aymurai_alt_start_char"] = start_char + leading_chars_removed
@@ -61,11 +63,11 @@ class AnonymizationEntityCleaner(Transform):
             DataItem: processed item
         """
         item = deepcopy(item)
-
         ents = get_element(item, [self.field, "entities"]) or []
 
-        # Filter out predictions that are punctuation marks only
-        ents = [ent for ent in ents if ent["text"] not in punctuation]
-        ents = [self.process(ent) for ent in ents]
+        # Filter out predictions with empty alt text and update the rest
+        item[self.field]["entities"] = [
+            out for ent in ents if (out := self.process(ent)) is not None
+        ]
 
         return item


### PR DESCRIPTION
This pull request refines the anonymization post-processing logic to better handle empty or invalid entities. The main improvements include filtering out entities with empty cleaned text and updating the entity processing pipeline for greater robustness.

Entity filtering and cleaning improvements:

* Updated the `process` method in `AnonymizationEntityCleaner` to return `None` for entities whose cleaned text is empty, ensuring that such entities are removed from the results.
* Modified the entity processing pipeline in the `__call__` method to filter out entities with empty cleaned text after processing, instead of only filtering out punctuation.

Code cleanup:

* Removed unused imports (`punctuation` from `string`) and reordered imports for clarity in `core.py`.

## Summary by Sourcery

Refine anonymization post-processing to drop entities whose cleaned text becomes empty and simplify entity handling in the transform.

Bug Fixes:
- Ensure entities with empty cleaned text are excluded from anonymization results instead of being retained as invalid entries.

Enhancements:
- Streamline the anonymization entity processing pipeline to process and filter entities in a single pass and remove unused imports.